### PR TITLE
Fix missing depth option for runtime header script generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(MODEL).o $(MODEL).json: $(MODEL).mlir
 	arcilator $< --state-file=$(MODEL).json | opt -O3 --strip-debug -S | llc -O3 --filetype=obj -o $(MODEL).o
 
 $(MODEL).h: $(MODEL).json
-	python $(ARCILATOR_UTILS_ROOT)/arcilator-header-cpp.py $< > $@
+	python $(ARCILATOR_UTILS_ROOT)/arcilator-header-cpp.py $< --view-depth 1 > $@
 
 $(MODEL).sv: $(MODEL).fir
 	firtool --verilog --dedup=1 $< -o $@


### PR DESCRIPTION
When the hierarchy levels option `--view-depth` are not explicitly specified, signal names like `rf/regs_ext` will not be exported to C++ structs.