### PR TITLE
[Rocket] add async-resets-as-sync arcilator flag

### DIFF
--- a/rocket/Makefile
+++ b/rocket/Makefile
@@ -18,7 +18,7 @@ $(shell mkdir -p $(BUILD_DIR))
 SOURCE_MODEL ?= rocket
 BUILD_MODEL ?= $(BUILD_DIR)/rocket
 
-ARCILATOR_ARGS ?= --mlir-timing --print-debug-info --mlir-pass-statistics
+ARCILATOR_ARGS ?= --mlir-timing --print-debug-info --mlir-pass-statistics --async-resets-as-sync
 VERILATOR_ARGS ?= -DPRINTF_COND=0 -DASSERT_VERBOSE_COND=0 -DSTOP_COND=0
 
 TRACE ?= 0


### PR DESCRIPTION
Modification to account for https://github.com/llvm/circt/pull/9360, which introduces the `--async-resets-as-sync` flag to Arcilator so that it requires users to explicitly specify they want their asynchronous resets to be interpreted as synchronous. This adds that flag to the Rocket Makefile - I didn't change it in the BOOM or Riscinator configs since AFAICT the versions we have of both are older versions of FIRRTL than CIRCT head supports anyway. 