### PR TITLE
Enable use of libCIRCTArcRuntime in Rocket and Boom models

### DIFF
--- a/boom/Makefile
+++ b/boom/Makefile
@@ -5,6 +5,12 @@ REPO_ROOT := ..
 BINARY ?= $(REPO_ROOT)/benchmarks/dhrystone.riscv
 CONFIG ?= small
 
+ARCRUNTIME ?= 0
+ARCRUNTIME_INCLUDE_DIR   ?= $(ARCILATOR_UTILS_ROOT)/../../include
+ARCRUNTIME_CIRCT_LIB_DIR ?= $(ARCILATOR_UTILS_ROOT)/../lib
+ARCRUNTIME_LLVM_LIB_DIR  ?= $(dir $(shell which llc))/../lib
+ARCRUNTIME_LINK_LIBS     := -lCIRCTArcRuntime -lLLVMSupport -lLLVMDemangle
+
 BUILD_DIR ?= build/$(CONFIG)
 $(shell mkdir -p $(BUILD_DIR))
 
@@ -22,6 +28,14 @@ ifeq ($(TRACE),1)
 	CXXFLAGS += -DTRACE
 else
 	ARCILATOR_ARGS += --observe-wires=0 --observe-ports=0 --observe-named-values=0 --observe-registers=0 --observe-memories=0
+endif
+
+ifeq ($(ARCRUNTIME),1)
+    ARCRUNTIME_CXXFLAGS  = -DARC_USE_COMPILED_RUNTIME_LIB
+    ARCRUNTIME_CXXFLAGS += -I$(ARCRUNTIME_INCLUDE_DIR)
+    ARCRUNTIME_LD_FLAGS  = -L$(ARCRUNTIME_CIRCT_LIB_DIR)
+    ARCRUNTIME_LD_FLAGS += -L$(ARCRUNTIME_LLVM_LIB_DIR)
+    ARCRUNTIME_LD_FLAGS += $(ARCRUNTIME_LINK_LIBS)
 endif
 
 #===-------------------------------------------------------------------------===
@@ -63,13 +77,13 @@ $(BUILD_MODEL)-vtor.a $(BUILD_MODEL)-vtor.h &: $(BUILD_MODEL).sv $(REPO_ROOT)/ve
 #===-------------------------------------------------------------------------===
 
 $(BUILD_MODEL)-model-arc.o: $(SOURCE_MODEL)-model-arc.cpp $(SOURCE_MODEL)-model.h $(BUILD_MODEL)-arc.h
-	$(CXX) $(CXXFLAGS) -I$(ARCILATOR_UTILS_ROOT)/ -I$(BUILD_DIR) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(ARCRUNTIME_CXXFLAGS) -I$(ARCILATOR_UTILS_ROOT)/ -I$(BUILD_DIR) -c $< -o $@
 
 $(BUILD_MODEL)-model-vtor.o: $(SOURCE_MODEL)-model-vtor.cpp $(SOURCE_MODEL)-model.h $(BUILD_MODEL)-vtor.h
 	$(CXX) $(CXXFLAGS) -I$(ARCILATOR_UTILS_ROOT)/ -I$(BUILD_DIR) -I/$(VERILATOR_ROOT)/include -c $< -o $@
 
 $(BUILD_MODEL)-main: $(SOURCE_MODEL)-main.cpp $(BUILD_MODEL)-model-arc.o $(BUILD_MODEL)-arc.o $(BUILD_MODEL)-model-vtor.o $(BUILD_MODEL)-vtor.a $(VERILATOR_ROOT)/include/verilated.cpp $(VERILATOR_ROOT)/include/verilated_vcd_c.cpp $(VERILATOR_ROOT)/include/verilated_threads.cpp
-	$(CXX) $(CXXFLAGS) -g -latomic -I$(REPO_ROOT)/elfio $^ -o $@
+	$(CXX) $(CXXFLAGS) $(ARCRUNTIME_CXXFLAGS) -g -latomic -I$(REPO_ROOT)/elfio $^ -o $@ $(ARCRUNTIME_LD_FLAGS)
 
 #===-------------------------------------------------------------------------===
 # Convenience

--- a/boom/boom-model-arc.cpp
+++ b/boom/boom-model-arc.cpp
@@ -10,7 +10,11 @@ class ArcilatorBoomModel : public BoomModel {
   std::unique_ptr<ValueChangeDump<BoomSystemLayout>> model_vcd;
 
 public:
-  ArcilatorBoomModel() { name = "arcs"; }
+  ArcilatorBoomModel()
+#ifdef ARC_USE_COMPILED_RUNTIME_LIB
+    : model(BoomSystem("debug"))
+#endif
+  { name = "arcs"; }
 
   void vcd_start(const char *outputFile) override {
     vcd_stream.open(outputFile);
@@ -25,7 +29,7 @@ public:
     }
   }
 
-  void eval() override { BoomSystem_eval(&model.storage[0]); }
+  void eval() override { model.eval(); }
 
   Ports get_ports() override {
     return {

--- a/rocket/Makefile
+++ b/rocket/Makefile
@@ -5,6 +5,12 @@ ARCILATOR_UTILS_ROOT ?= $(dir $(shell which arcilator))
 BINARY ?= $(REPO_ROOT)/benchmarks/dhrystone.riscv
 CONFIG ?= small-v1.6
 
+ARCRUNTIME ?= 0
+ARCRUNTIME_INCLUDE_DIR   ?= $(ARCILATOR_UTILS_ROOT)/../../include
+ARCRUNTIME_CIRCT_LIB_DIR ?= $(ARCILATOR_UTILS_ROOT)/../lib
+ARCRUNTIME_LLVM_LIB_DIR  ?= $(dir $(shell which llc))/../lib
+ARCRUNTIME_LINK_LIBS     := -lCIRCTArcRuntime -lLLVMSupport -lLLVMDemangle
+
 CXXFLAGS = -O3 -Wall -std=c++17
 LDFLAGS =
 ifeq ($(shell uname), Linux)
@@ -29,6 +35,14 @@ ifeq ($(TRACE),1)
 	CXXFLAGS += -DTRACE
 else
 	ARCILATOR_ARGS += --observe-wires=0 --observe-ports=0 --observe-named-values=0 --observe-registers=0 --observe-memories=0
+endif
+
+ifeq ($(ARCRUNTIME),1)
+    ARCRUNTIME_CXXFLAGS  = -DARC_USE_COMPILED_RUNTIME_LIB
+    ARCRUNTIME_CXXFLAGS += -I$(ARCRUNTIME_INCLUDE_DIR)
+    ARCRUNTIME_LD_FLAGS  = -L$(ARCRUNTIME_CIRCT_LIB_DIR)
+    ARCRUNTIME_LD_FLAGS += -L$(ARCRUNTIME_LLVM_LIB_DIR)
+    ARCRUNTIME_LD_FLAGS += $(ARCRUNTIME_LINK_LIBS)
 endif
 
 #===-------------------------------------------------------------------------===
@@ -70,13 +84,13 @@ $(BUILD_MODEL)-vtor.a $(BUILD_MODEL)-vtor.h &: $(BUILD_MODEL).sv $(REPO_ROOT)/ve
 #===-------------------------------------------------------------------------===
 
 $(BUILD_MODEL)-model-arc.o: $(SOURCE_MODEL)-model-arc.cpp $(SOURCE_MODEL)-model.h $(BUILD_MODEL)-arc.h
-	$(CXX) $(CXXFLAGS) -I$(ARCILATOR_UTILS_ROOT)/ -I$(BUILD_DIR) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(ARCRUNTIME_CXXFLAGS) -I$(ARCILATOR_UTILS_ROOT)/ -I$(BUILD_DIR) -c $< -o $@
 
 $(BUILD_MODEL)-model-vtor.o: $(SOURCE_MODEL)-model-vtor.cpp $(SOURCE_MODEL)-model.h $(BUILD_MODEL)-vtor.h
 	$(CXX) $(CXXFLAGS) -I$(ARCILATOR_UTILS_ROOT)/ -I$(BUILD_DIR) -I/$(VERILATOR_ROOT)/include -c $< -o $@
 
 $(BUILD_MODEL)-main: $(SOURCE_MODEL)-main.cpp $(BUILD_MODEL)-model-arc.o $(BUILD_MODEL)-arc.o $(BUILD_MODEL)-model-vtor.o $(BUILD_MODEL)-vtor.a $(VERILATOR_ROOT)/include/verilated.cpp $(VERILATOR_ROOT)/include/verilated_vcd_c.cpp $(VERILATOR_ROOT)/include/verilated_threads.cpp
-	$(CXX) $(CXXFLAGS) -g $(LDFLAGS) -I$(REPO_ROOT)/elfio $^ -o $@ -DVL_TIME_CONTEXT
+	$(CXX) $(CXXFLAGS) $(ARCRUNTIME_CXXFLAGS) -g $(LDFLAGS) -I$(REPO_ROOT)/elfio $^ -o $@ -DVL_TIME_CONTEXT $(ARCRUNTIME_LD_FLAGS)
 
 #===-------------------------------------------------------------------------===
 # Convenience

--- a/rocket/rocket-model-arc.cpp
+++ b/rocket/rocket-model-arc.cpp
@@ -10,7 +10,11 @@ class ArcilatorRocketModel : public RocketModel {
   std::unique_ptr<ValueChangeDump<RocketSystemLayout>> model_vcd;
 
 public:
-  ArcilatorRocketModel() { name = "arcs"; }
+  ArcilatorRocketModel()
+#ifdef ARC_USE_COMPILED_RUNTIME_LIB
+    : model(RocketSystem("debug"))
+#endif
+    { name = "arcs"; }
 
   void vcd_start(const char *outputFile) override {
     vcd_stream.open(outputFile);
@@ -25,7 +29,7 @@ public:
     }
   }
 
-  void eval() override { RocketSystem_eval(&model.storage[0]); }
+  void eval() override { model.eval(); }
 
   Ports get_ports() override {
     return {


### PR DESCRIPTION
Provide the option to build and link the Rocket and Boom models to the recently added Arcilator runtime library by setting `ARCRUNTIME=1`.
I had to do a small change to the `eval` methods to ensure the runtime libraries' `onEval` function gets called. I've added the `debug` argument to the instance, so we can see it is actually used:
```
$ ARCRUNTIME=1 make CONFIG=small-master -C rocket run-arcs
[...]
build/small-master/rocket-main ../benchmarks/dhrystone.riscv --arcs
loading segment at 60000000 (virtual address 60000000)
loading segment at 80000000 (virtual address 80000000)
entry 80000000
loaded 20888 program bytes
[ArcRuntime] Created instance of model "RocketSystem" with ID 0
[ArcRuntime] Instance with ID 0 initialized
Microseconds for one run through Dhrystone: 801
Dhrystones per Second:                      1247
mcycle = 400992
minstret = 192528
Benchmark run successful!
----------------------------------------
413515 cycles total
arcs: 581206 Hz
[ArcRuntime] Deleting instance of model "RocketSystem" with ID 0 after 1239545 step(s)
```

For builds with `ARCRUNTIME=0` nothing should change.